### PR TITLE
Upgrading the Faraday gem from version 1.0.0 to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #--------------------------------------------------------------------------
 source "https://rubygems.org" do
-  gem "faraday",             "~> 1.0", :require => false
+  gem "faraday",             "~> 2.0", :require => false
   gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
   gem "net-http-persistent", "~> 4.0", :require => false
   gem "nokogiri",          "~> 1", ">= 1.10.8", :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@
 #--------------------------------------------------------------------------
 source "https://rubygems.org" do
   gem "faraday",             "~> 2.0", :require => false
-  gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
+  gem "faraday-follow_redirects", "~> 0.3.0", :require => false
+  gem "faraday-net_http_persistent", "~> 2.0", :require => false
   gem "net-http-persistent", "~> 4.0", :require => false
   gem "nokogiri",          "~> 1", ">= 1.10.8", :require => false
   gem "adal",                "~> 1.0", :require => false

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -42,7 +42,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency('faraday',                 '~> 2.0')
-  s.add_runtime_dependency('faraday_middleware',      "~> 1.0", ">= 1.0.0.rc1")
+  s.add_runtime_dependency('faraday-follow_redirects','~> 0.3.0')
+  s.add_runtime_dependency('faraday-net_http_persistent', '~> 2.0')
   s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.10.8")
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency('faraday',                 '~> 1.0')
+  s.add_runtime_dependency('faraday',                 '~> 2.0')
   s.add_runtime_dependency('faraday_middleware',      "~> 1.0", ">= 1.0.0.rc1")
   s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   s.add_runtime_dependency("nokogiri",                "~> 1", ">= 1.10.8")

--- a/common/lib/azure/core.rb
+++ b/common/lib/azure/core.rb
@@ -16,7 +16,8 @@
 require 'rubygems'
 require 'nokogiri'
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
+require 'faraday/net_http_persistent'
 
 module Azure
   module Core

--- a/common/lib/azure/storage/common/autoload.rb
+++ b/common/lib/azure/storage/common/autoload.rb
@@ -30,7 +30,7 @@ require "base64"
 require "openssl"
 require "uri"
 require "faraday"
-require "faraday_middleware"
+require 'faraday/follow_redirects'
 
 require "azure/storage/common/core/autoload"
 require "azure/storage/common/default"

--- a/common/lib/azure/storage/common/client_options.rb
+++ b/common/lib/azure/storage/common/client_options.rb
@@ -283,7 +283,7 @@ module Azure::Storage::Common
       def is_url
         Proc.new do |i|
           i = "http://" + i unless i =~ /\Ahttps?:\/\//
-          i =~ URI.regexp(["http", "https"])
+          i =~ URI::DEFAULT_PARSER.make_regexp(["http", "https"])
         end
       end
 

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -71,7 +71,7 @@ module Azure::Storage::Common::Core
                           URI::parse(ENV["HTTPS_PROXY"])
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
-          conn.use FaradayMiddleware::FollowRedirects
+          conn.response :follow_redirects #use Faraday::FollowRedirects::Middleware
           conn.adapter :net_http_persistent, pool_size: 5 do |http|
             # yields Net::HTTP::Persistent
             http.idle_timeout = 100

--- a/common/lib/azure/storage/common/service/storage_service.rb
+++ b/common/lib/azure/storage/common/service/storage_service.rb
@@ -239,8 +239,8 @@ module Azure::Storage::Common
 
         # Registers the callback when sending the request
         # The headers in the request can be viewed or changed in the code block
-        def register_request_callback
-          @request_callback = Proc.new
+        def register_request_callback(&block)
+          @request_callback = block
         end
 
         # Get the request location.

--- a/table/lib/azure/storage/table/table_service.rb
+++ b/table/lib/azure/storage/table/table_service.rb
@@ -746,7 +746,7 @@ module Azure::Storage
           value = value.gsub("'", "''")
 
           # Encode the special URL characters
-          value = URI.escape(value)
+          value = URI.encode_www_form_component(value)
 
           value
         end


### PR DESCRIPTION
## 🖼️ Context
Upgrading the `Faraday` gem from version `1.0.0 to 2.0`. 

fix #227
## ✅ Approach 

- In the process of upgrading the `faraday` gem to version 2.0 from 1.0,  I need to remove the `faraday_middleware` as it has been deprecated based on its [docs](https://github.com/lostisland/faraday_middleware) and need to use the middleware `faraday-follow_redirects`. Details are present in the [awesome-faraday docs](https://github.com/lostisland/awesome-faraday).
- Based on the `Faraday` [upgrade docs](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#thats-great-what-should-i-change-in-my-code-immediately-after-upgrading), all the adapters, except for the `net_http`, have already been moved out and released as separate gems. So I had to add adapter `faraday-net_http_persistent` (gem) as part of this upgrade.